### PR TITLE
manifest: Update to BaseApp 24.04 and Runtime 46beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Music Keyboard Activity Flatpak
+
+Displays a piano keyboard on the screen for playing music using different instruments. Notes can be played with touch screen or typing keyboard.
+
+To know more refer https://github.com/godiard/music-keyboard-activity
+
+## How To Build
+
+```
+git clone https://github.com/flathub/org.sugarlabs.MusicKeyboard
+cd org.sugarlabs.MusicKeyboard
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
+flatpak -y --user install org.sugarlabs.BaseApp//24.04
+flatpak-builder --user --force-clean --install build org.sugarlabs.MusicKeyboard.json
+```
+
+## Check For Updates
+
+Install the flatpak external data checker
+```
+flatpak --user install org.flathub.flatpak-external-data-checker
+```
+
+Now to update every single module to the latest stable version use
+```
+cd org.sugarlabs.MusicKeyboard
+flatpak run --filesystem=$PWD org.flathub.flatpak-external-data-checker org.sugarlabs.MusicKeyboard.json
+```

--- a/musickeyboard-info.patch
+++ b/musickeyboard-info.patch
@@ -2,7 +2,7 @@ diff --git a/activity/activity.info b/activity/activity.info
 index 27a22db..f0035a1 100644
 --- a/activity/activity.info
 +++ b/activity/activity.info
-@@ -5,8 +5,15 @@ bundle_id = org.sugarlabs.MusicKeyboard
+@@ -5,8 +5,16 @@ bundle_id = org.sugarlabs.MusicKeyboard
  exec = sugar-activity3 activity.SimplePianoActivity
  icon = activity-simplepiano
  license = GPLv2+
@@ -20,3 +20,4 @@ index 27a22db..f0035a1 100644
 +screenshots = https://raw.githubusercontent.com/godiard/music-keyboard-activity/master/screenshots/en/1.png
 +url = https://help.sugarlabs.org/en/musickeyboard.html
 +developer_name = Sugar Labs Community
++developer_id = org.sugarlabs

--- a/org.sugarlabs.MusicKeyboard.json
+++ b/org.sugarlabs.MusicKeyboard.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.MusicKeyboard",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "23.06",
+    "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/org.sugarlabs.MusicKeyboard.json
+++ b/org.sugarlabs.MusicKeyboard.json
@@ -34,13 +34,29 @@
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
                     "sha256": "7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
-                    "only-arches": ["aarch64"]
+                    "only-arches": ["aarch64"],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://pypi.org/pypi/numpy/json",
+                        "version-query": ".info.version",
+                        "url-query": ".releases | .[$version][] | select(.filename==\"numpy-\" + $version + \"-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\") | .url",
+                        "name": "numpy",
+                        "packagetype": "bdist_wheel"
+                   }
                },
                {
                 "type": "file",
                 "url": "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
                 "sha256": "666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
-                "only-arches": ["x86_64"]
+                "only-arches": ["x86_64"],
+                "x-checker-data": {
+                    "type": "json",
+                    "url": "https://pypi.org/pypi/numpy/json",
+                    "version-query": ".info.version",
+                    "url-query": ".releases | .[$version][] | select(.filename==\"numpy-\" + $version + \"-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\") | .url",
+                    "name": "numpy",
+                    "packagetype": "bdist_wheel"
+                }
             }
             ],
             "cleanup": [

--- a/org.sugarlabs.MusicKeyboard.json
+++ b/org.sugarlabs.MusicKeyboard.json
@@ -27,18 +27,21 @@
             "name": "numpy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --no-build-isolation --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} numpy"
+                "pip3 install --exists-action=i --no-build-isolation --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} *.whl"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d0/b2/fe774844d1857804cc884bba67bec38f649c99d0dc1ee7cbbf1da601357c/numpy-1.25.0.tar.gz",
-                    "sha256": "f1accae9a28dc3cda46a91de86acf69de0d1b5f4edd44a9b0c3ceb8036dfff19",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "numpy"
-                    }
-                }
+                    "url": "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
+                    "only-arches": ["aarch64"]
+               },
+               {
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "sha256": "666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
+                "only-arches": ["x86_64"]
+            }
             ],
             "cleanup": [
                 "/bin",

--- a/org.sugarlabs.MusicKeyboard.json
+++ b/org.sugarlabs.MusicKeyboard.json
@@ -57,7 +57,7 @@
             "build-options": {
                 "env": {
                     "PYTHONHOME": "/app",
-                    "PYTHONPATH": "/usr/lib/python3.10"
+                    "PYTHONPATH": "/usr/lib/python3.11"
                 },
                 "arch": {
                     "arm": {


### PR DESCRIPTION
updated manifest and README file
numpy was throwing an error
`ModuleNotFoundError: No module named 'mesonpy'`
To fix this new module `meson-python` is added to manifest and it is compatible with flatpak-external-data-checker

After this mesonpy reporting module not found
`ModuleNotFoundError: No module named 'pyproject_metadata'`
To fix this new module `pyproject-metadata` is added to manifest and it is compatible with flatpak-external-data-checker